### PR TITLE
middleman build error without sass-bootstrap

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "tests"
   ],
   "dependencies": {
+    "sass-bootstrap": "~3.0",
     "jquery": "~2.0",
     "modernizr": "~2.6.3",
     "respond": "~1.4.2",

--- a/config.rb
+++ b/config.rb
@@ -158,7 +158,7 @@ configure :build do
   # activate :asset_hash
 
   # Use relative URLs
-  # activate :relative_assets
+  activate :relative_assets
 
   # Or use a different image path
   # set :http_prefix, "/Content/images/"


### PR DESCRIPTION
middleman build error without sass-bootstrap
set activate :relative_assets in config.rb
