### PR TITLE
meta description issue when using md inline html

### DIFF
--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -3,6 +3,8 @@ html
   head
     meta[charset="utf-8"]
     meta[http-equiv="X-UA-Compatible" content="IE=edge;chrome=1"]
+    / Required to enable bootstrap mobile
+    meta[name="viewport" content="width=device-width, initial-scale=1"]
     title
       = page_title
     = feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml", title: "Atom Feed"


### PR DESCRIPTION
Removed the entry `meta[name="description" content="#{page_description}"]`, due to the fact that any markdown with inline html will result in problem. I.e. the inline html will be rendered into the the layout itself, instead put in the meta decscription.
E.g. `<div style="">...</div>`
